### PR TITLE
authors.json: add armaku (PeekAView)

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -7,6 +7,13 @@
                 "c0fe7daaa1fbd1ee54096d96669a7bbb10cd0a2ad08949d664d4804c50e34db1"
             ],
             "name": "Zed"
+        },
+        {
+            "id": 76561198062896516,
+            "keys": [
+                "61256bafeedc1d0c4843081470f90db737e0cc700531f7aa8b4327e1eb3cf3a8"
+            ],
+            "name": "armaku"
         }
     ],
     "signature": "a0228c1f04b820170ae5890196561162fdc98f2bd877d437aa4b2c4f8b243cceb05226cc90d65a50d3ce2c84b2003448142b5bcda3e3e14d38fe386078db5b0f"


### PR DESCRIPTION
Adding my entry to authors.json per the ModSigning doc. Following up on the
DM I sent earlier today.

- SteamID64: 76561198062896516
- Display name: armaku
- Pubkey: 61256bafeedc1d0c4843081470f90db737e0cc700531f7aa8b4327e1eb3cf3a8

Identity check: I'm the author of PeekAView on the Steam Workshop
(https://steamcommunity.com/sharedfiles/filedetails/?id=3710281407), which
is published from the same Steam account.

Left `signature` and `updated_at` untouched, assuming you'll regenerate on
merge.