### PR TITLE
Add enry of alitz to known authors

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -1,5 +1,5 @@
 {
-    "updated_at": "2026-05-01T00:00:00Z",
+    "updated_at": "2026-06-27T00:00:00Z",
     "authors": [
         {
             "id": 76561198043849998,
@@ -7,6 +7,13 @@
                 "c0fe7daaa1fbd1ee54096d96669a7bbb10cd0a2ad08949d664d4804c50e34db1"
             ],
             "name": "Zed"
+        },
+        {
+            "id": 76561198063443193,
+            "keys": [
+                "f121bcb87764ccc56466f74b68295e04b69ebfedee0b73b67813346f16f43e67"
+            ],
+            "name": "enry of alitz"
         }
     ],
     "signature": "a0228c1f04b820170ae5890196561162fdc98f2bd877d437aa4b2c4f8b243cceb05226cc90d65a50d3ce2c84b2003448142b5bcda3e3e14d38fe386078db5b0f"


### PR DESCRIPTION
﻿## Summary

Adds `enry of alitz` to the known authors registry.

Author details:

- SteamID64: `76561198063443193`
- Public ZBS key: `f121bcb87764ccc56466f74b68295e04b69ebfedee0b73b67813346f16f43e67`

## Notes

I updated `updated_at` with the PR date. I did not regenerate the `authors.json` signature because that requires the maintainer signing key. Please re-run the repository author-signing task before merge/release so the published registry verifies correctly.

## Validation

- Parsed `authors.json` locally with PowerShell `ConvertFrom-Json`.
