### PR TITLE
Correct modding guide typos

### DIFF
--- a/doc/ModdingGuide.md
+++ b/doc/ModdingGuide.md
@@ -146,10 +146,10 @@ Use `PreMain` only for work that truly needs early hooks. Put normal initializat
 ```java
 package com.yourname.yourmod.patches;
 
-import me.zed_0xff.zombie_buddy.annotations.Patch;
+import me.zed_0xff.zombie_buddy.Patch;
 
 @Patch(className = "zombie.SomeGameClass", methodName = "someMethod", warmUp = true)
-public static class MyPatch {
+public class MyPatch {
     @Patch.OnEnter
     public static void enter() {
         System.out.println("[YourMod] Intercepted method call!");


### PR DESCRIPTION
Fixes a couple typos in the modding guide's patch example that threw me for a loop:
- Imports Patch from the correct package
- Removes the static modifier from the patch class since it is not valid for root level classes (presumably it was based on some code where patches are enclosed classes).