### PR TITLE
authors.json: add IKappaID

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -35,6 +35,13 @@
                 "1987f95772831b20215bbef4481cd8e42140e17c30869b7bf87d9773f51f3c89"
             ],
             "name": "ILC233"
+        },
+        {
+            "id": 76561198273218719,
+            "keys": [
+                "465dda4ba32a507acfa85ce6952bdcc4ab3f0f389c0cf5a85f86f7e6762ea785"
+            ],
+            "name": "IKappaID"
         }
     ],
     "signature": "8f5fe50e12c372a7f05e4adf48730e1616ee79b6b330c5771cfb4382e1c030c9ff18909c3ceb5e5fbec88f05f122e151b2c0249bc9dcbd506d28585c9d3a3406"


### PR DESCRIPTION
Adding my entry to authors.json per [ModSigning.md](https://github.com/zed-0xff/ZombieBuddy/blob/master/doc/ModSigning.md).

- SteamID64: 76561198273218719
- Display name: IKappaID
- Public key: 465dda4ba32a507acfa85ce6952bdcc4ab3f0f389c0cf5a85f86f7e6762ea785

Identity check: I'm the author of IKappaID & Faded's True Real World Vehicle Physics on Steam Workshop
(https://steamcommunity.com/sharedfiles/filedetails/?id=3749738289), published from this Steam account
(https://steamcommunity.com/profiles/76561198273218719).

The Java sub-mod IKFRVP Java Physics ships `ikfrvp-java.jar` with a matching `.zbs` sidecar signed with this key.

Left `signature` and `updated_at` untouched — assuming you'll regenerate on merge.