### PR TITLE
Add author: Saint (RagdollsInMP)

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -35,6 +35,13 @@
                 "1987f95772831b20215bbef4481cd8e42140e17c30869b7bf87d9773f51f3c89"
             ],
             "name": "ILC233"
+        },
+        {
+            "id": 76561199128207983,
+            "keys": [
+                "760e7ced774b4e88e6f6789c266985e50e3b772992a9250c6a985b01453fff4b"
+            ],
+            "name": "Saint"
         }
     ],
     "signature": "8f5fe50e12c372a7f05e4adf48730e1616ee79b6b330c5771cfb4382e1c030c9ff18909c3ceb5e5fbec88f05f122e151b2c0249bc9dcbd506d28585c9d3a3406"


### PR DESCRIPTION
## Summary
- Requesting to be added to the known authors list so I can sign my Java mod "Ragdolls in Multiplayer".

## Details
- SteamID64: `76561199128207983`
- Display name: Saint
- Public key: `760e7ced774b4e88e6f6789c266985e50e3b772992a9250c6a985b01453fff4b`

I verified locally that this key correctly verifies the `ZBS:<SteamID64>:<JAR_SHA256>` canonical payload for my mod's signed jar, so the entry should be accurate. I understand `signature` will need to be regenerated by the maintainer after merge.