### PR TITLE
authors.json: add 老余

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -35,6 +35,13 @@
                 "1987f95772831b20215bbef4481cd8e42140e17c30869b7bf87d9773f51f3c89"
             ],
             "name": "ILC233"
+        },
+        {
+            "id": 76561198258764906,
+            "keys": [
+                "0f99c4e5bfe0c9de71569c31bd627001aa17e9a714f9abe39038d0e51d176f88"
+            ],
+            "name": "老余"
         }
     ],
     "signature": "8f5fe50e12c372a7f05e4adf48730e1616ee79b6b330c5771cfb4382e1c030c9ff18909c3ceb5e5fbec88f05f122e151b2c0249bc9dcbd506d28585c9d3a3406"


### PR DESCRIPTION
## Summary

- add SteamID64 `76561198258764906` as known author `老余`
- register the Ed25519 public key already published on the author's Steam profile
- leave the repository-managed `signature` unchanged for maintainer re-signing

## Why

This gives ZombieBuddy a stable human-readable author name and authoritative public-key mapping instead of displaying the raw SteamID64.

## Validation

- parsed `authors.json` successfully
- verified the SteamID64 and public key each appear exactly once
- ran `git diff --check`