### PR TITLE
Add Alswyn to authors.json

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -70,6 +70,13 @@
       "keys": [
         "0ae56541e4aa658a2c907845f721ae0476b5e32b5d042c5107c5c352cb836116"
       ]
+    },
+    {
+      "id": 76561198014024358,
+      "keys": [
+        "8979b4c691946c54d4b31a02729c0e94609dc1fff2c7432d2840f2c63e561a77"
+      ],
+      "name": "Alswyn"
     }
   ],
   "signature": "a83de9048a51c91c443c94548e1ebd3eea2daa785646b84f5059eb28da1bd7a02e611b70131387699cea59327de6d2f6ec8ad381b8142865e98b96cee0cdfb05"


### PR DESCRIPTION
Please add my SteamID64 and public Ed25519 key to the ZombieBuddy author registry.

This is for the mod Zomboid Rich Presence, which now ships as a signed Java mod using ZBS. The current Workshop release has been tested and is successfully reported as ZBS verification valid by ZombieBuddy.